### PR TITLE
Install TAU and try to improve caching

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,6 @@
-.git
-.github
+/.git/
+Dockerfile
+**/.DS_Store
+/.github/
 *.md
 LICENSE

--- a/.github/actions/docker-cache/backup.sh
+++ b/.github/actions/docker-cache/backup.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+# shellcheck source=timing.sh
+. "${BASH_SOURCE%/*}/timing.sh"
+
+main() {
+  local cache_tar=$1
+  local cache_dir
+  cache_dir=$(dirname "$cache_tar")
+
+  mkdir -p "$cache_dir"
+  rm -f "$cache_tar"
+
+  timing sudo service docker stop
+  timing sudo /bin/tar -c -f "$cache_tar" -C /var/lib/docker .
+  sudo chown "$USER:$(id -g -n "$USER")" "$cache_tar"
+  ls -lh "$cache_tar"
+}
+
+main "$@"

--- a/.github/actions/docker-cache/restore.sh
+++ b/.github/actions/docker-cache/restore.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+# shellcheck source=timing.sh
+. "${BASH_SOURCE%/*}/timing.sh"
+
+main() {
+  local cache_tar=$1
+
+  if [[ -f "$cache_tar" ]]; then
+    ls -lh "$cache_tar"
+    timing sudo service docker stop
+    # mv is c. 25 seconds faster than rm -rf here
+    timing sudo mv /var/lib/docker "$(mktemp -d --dry-run)"
+    sudo mkdir -p /var/lib/docker
+    timing sudo tar -xf "$cache_tar" -C /var/lib/docker
+    timing sudo service docker start
+  else
+    # Slim docker down - comes with 3GB of data we don't want to backup
+    timing docker system prune -a -f --volumes
+  fi
+}
+
+main "$@"

--- a/.github/actions/docker-cache/timing.sh
+++ b/.github/actions/docker-cache/timing.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+timing() {
+  command time -f "[$*] took %E" "$@"
+}

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -2,6 +2,8 @@ name: ci
 # See https://docs.docker.com/build/ci/github-actions/examples
 
 on:
+  schedule:
+    - cron: "41 1 * * */1"
   push:
     branches:
       - "**"
@@ -11,7 +13,7 @@ on:
     branches:
       - "main"
 jobs:
-  build:
+  build-base:
     runs-on: ubuntu-latest
     steps:
       -
@@ -25,13 +27,14 @@ jobs:
             ghcr.io/paratoolsinc/salt-dev
           # generate Docker tags based on the following events/attributes
           tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
             type=ref,event=branch
             type=ref,event=pr
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
             type=sha
-          # type=schedule
+            type=schedule
       -
         name: Checkout
         uses: actions/checkout@v3

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,12 +28,12 @@ RUN for p in gcc g++ clang clang++ cc c++; do ln -vs /usr/bin/ccache /usr/local/
 ARG CI=false
 # Clone LLVM repo. A shallow clone is faster, but pulling a cached repository is faster yet
 RUN --mount=type=cache,target=/git <<EOC
-  echo "Checking out LLVM"
+  echo "Checking out LLVM."
   echo "\$CI = $CI"
   env | grep -i github
   if ${CI:-false}; then
     # Github CI never seems to use the cached git directory :-[
-    echo "Running under CI. \$CI=$CI. Shallow cloning will be used if a clone is required"
+    echo "Running under CI. \$CI=$CI. Shallow cloning will be used if a clone is required."
     export SHALLOW='--depth=1'
   fi
   if mkdir llvm-project && git --git-dir=/git/llvm-project.git -C llvm-project pull origin release/14.x --ff-only

--- a/Dockerfile
+++ b/Dockerfile
@@ -115,14 +115,18 @@ RUN --mount=type=cache,target=/var/cache/apt,sharing=locked --mount=type=cache,t
   rm -rf /var/lib/apt/lists/*
 EOC
 
-RUN for p in clang clang++ cc c++; do ln -vs /usr/bin/ccache /usr/local/bin/$p;  done
-
 # Get ninja from builder
 COPY --from=builder /usr/local/bin/ninja /usr/local/bin/
 
 # Copy build results of stage 1 to /usr/local.
-COPY --from=builder /tmp/llvm/ /usr/local/
+COPY --from=builder /tmp/llvm/ /usr/
 
+# Setup ccache
 ENV CCACHE_DIR=/home/salt/ccache
-RUN mkdir -p $CCACHE_DIR
+RUN <<EOC
+  for p in gcc g++ clang clang++ cc c++; do
+    ln -vs /usr/bin/ccache /usr/local/bin/$p
+  done
+EOC
+
 WORKDIR /home/salt/

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,3 +130,21 @@ RUN <<EOC
 EOC
 
 WORKDIR /home/salt/
+
+# Download and install TAU
+# http://tau.uoregon.edu/tau.tgz
+# http://fs.paratools.com/tau-mirror/tau.tgz
+# http://fs.paratools.com/tau-nightly.tgz
+RUN --mount=type=cache,target=/home/salt/ccache <<EOC
+  ccache -s
+  wget http://tau.uoregon.edu/tau.tgz || wget http://fs.paratools.com/tau-mirror/tau.tgz
+  tar xzvf tau.tgz
+  cd tau*
+  ./installtau -prefix=/usr/local/ \
+    -bfd=download -unwind=download -dwarf=download -pthread -iowrapper -j
+  cd ..
+  rm -rf tau*
+  ccache -s
+EOC
+
+ENV PATH="${PATH}:/usr/local/x86_64/bin"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,84 @@
 # salt-dev
-Container definitions for SALT development
+
+[![ci](https://github.com/ParaToolsInc/salt-dev/actions/workflows/CI.yml/badge.svg)](https://github.com/ParaToolsInc/salt-dev/actions/workflows/CI.yml)
+
+Container definitions for [SALT] development.
+
+This repository defines and deploys the containers used for [SALT] continuous integration (CI) and local development.
+
+## Building the development container for local use
+
+First, BuildKit, caching and intelligent layer creation and ordering have been employed
+in an attempt to minimize time spent waiting for the container to build.
+Certain operations are unavoidably expensive when performed for the first time,
+however, steps have been taken to maximize caching and minimuze rebuild times.
+The first build on a new machine will always be expensive but subsequent updates
+should be comparatively snappy and painless.
+
+To build the development image with BuildKit, the following command may be employed:
+
+``` shell
+docker buildx build --pull -t salt-dev --load .
+```
+
+To usethe development image in testing, something like this should work:
+
+``` shell
+docker run -it --tmpfs=/dev/shm:rw,nosuid,nodev,exec --privileged -v $(pwd):/home/salt/src salt-dev
+```
+
+This will mount the working directory (usually your SALT worktree) into `/home/salt/src`.
+
+## Optimizations for expensive build steps
+
+The following discusses the major pain points and the steps taken to minimize them.
+
+### Compiling LLVM/Clang
+
+This is by far the most expensive step.
+On a 2.4 GHz 8-Core Intel Core i9 Mac Book Pro,
+the initial build of this image layer takes approximately 150-200 minutes.
+It is therefore important that:
+
+1. This layer is built early to maximise the opportunity for reuse
+2. Cheaper steps that are likely to change should be placed after the `RUN` step compiling llvm/clang in the `Dockerfile`
+3. Some sort of compiler cache is employed, here we use ccache, to speed up the build even when the layer needs to be rebuilt
+4. The compiler cache needs to be made available to the build even when the layer is rebuilt.
+
+The first build will still take a long time (~150-200 minutes on a 2.4 GHz 8-Core Intel Core i9),
+however subsequent rebuilds will take about 1 minute (on a 2.4 GHz 8-Core Intel Core i9) when the cache is
+present.
+This is acheived through the use of `ccache` and the `--mount=type=cache,target=/some/path` option to the
+`RUN` command in the Dockerfile.
+In the event that previous layers have not changed and neither has the layer defining the llvm/clang compilation,
+then, of course, a previous cached layer may just be reused taking about a second or so.
+
+### Cloning/updating llvm-project
+
+Shallow clones are fastest, but they are less than performant when a subsequent update of the repository
+(via `git fetch` or `git pull`) is required.
+An alternate to shallow clones is to use the `--filter=blob:none` option,
+which fetches entire histories, commits and trees, but only the blobs needed by `HEAD`.
+This allows the repository to be worked with and updated in an efficient way takes considerably less time
+than a full clone.
+(On a 2.4 GHz 8-Core Intel Core i9 with ~40 Mbit/s download speed `--single-branch` and `--filter=blob:none`
+reduce the clone time from over 5 minutes to 2.5-3 minutes.
+A shallow clone using `--single-branch` and `--depth=1` takes about 1.5-2 minutes.)
+By not using a shallow clone, we can cache the `.git` folder, and efficiently reset the work tree and
+fetch any updates on the branch if the cache exists.
+If the cache doesn't exist a new clone is performed.
+
+### Package installation via `apt`
+
+Caching of `apt` packages that can be potentially shared was implemented following the example
+[here](https://docs.docker.com/engine/reference/builder/#run---mounttypecache)
+
+### GitHub Actions caching
+
+Using the official docker GitHub Actions with their support for caching maximizes the amount of caching and
+efficiency of building the image(s) during CI.
+Very useful examples are available [here](https://docs.docker.com/build/ci/github-actions/examples).
+
+
+
+[SALT]: https://github.com/ParaToolsInc/salt


### PR DESCRIPTION
* See [Mahoney-playground/docker-cache-action] for some links and workarounds to `RUN --mount=type=cache,target=` issues on GHA
  * Ultimately it appears the strategy in [Mahoney-playground/docker-cache-action] appears not to be fully compatible with the official docker github actions so the caching was reverted
* Improve README file with discussion of techniques and some instructions to run and build the images locally
* Install TAU in the development image

[Mahoney-playground/docker-cache-action]: https://github.com/Mahoney-playground/docker-cache-action