### PR TITLE
Revert to more minimal install & fix TAU/libompstub issue & bad flang install

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -184,7 +184,7 @@ RUN --mount=type=cache,target=/home/salt/ccache <<EOC
   ./installtau -prefix=/usr/local/ -cc=clang -c++=clang++ -fortran=flang\
     -bfd=download -unwind=download -dwarf=download -otf=download -zlib=download -pthread -j
   cd ..
-  rm -rf tau*
+  rm -rf tau* libdwarf-* otf2-*
   ccache -s
   ls
 EOC

--- a/Dockerfile
+++ b/Dockerfile
@@ -190,4 +190,5 @@ RUN --mount=type=cache,target=/home/salt/ccache <<EOC
 EOC
 
 ENV PATH="${PATH}:/usr/local/x86_64/bin"
-RUN alias ls="ls --color=auto"
+ENV TAU_ROOT=/usr/local
+WORKDIR /home/salt/src

--- a/Dockerfile
+++ b/Dockerfile
@@ -110,14 +110,13 @@ RUN --mount=type=cache,target=/ccache/ <<EOC
   ninja -j $(( $(nproc --ignore=4) > 2 ? $(nproc --ignore=1) : 2)) install > build.log 2>&1 &
   build_pid=$!
   while kill -0 $build_pid 2>/dev/null; do
-    tail -n 8 build.log
+    tail -n 4 build.log
     sleep 90
   done
   wait $build_pid
   tail -n 100 build.log
-  if ! [[ "X${CI}" == "Xfalse" ]] ; then # reclaim space in CI
-    rm -rf /llvm-project/llvm/build
-  fi
+  rm -rf /llvm-project/llvm/build # reclaim space, should be cached anyway by ccache
+  ccache -s
 EOC
 
 # Patch installed cmake exports/config files to not throw an error if not all components are installed

--- a/Dockerfile
+++ b/Dockerfile
@@ -135,8 +135,8 @@ RUN <<EOC
   FLANG_NEW_DIR="$(dirname $FLANG_NEW)"
   cd "$FLANG_NEW_DIR"
   pwd
-  ls -la
   ln -s flang-new flang # remove for LLVM 20
+  ls -la
 EOC
 
 # Patch installed cmake exports/config files to not throw an error if not all components are installed

--- a/Dockerfile
+++ b/Dockerfile
@@ -129,7 +129,15 @@ RUN --mount=type=cache,target=/ccache/ <<EOC
   ccache -s
 EOC
 
-RUN ln -s /tmp/llvm/bin/flang-new /tmp/llvm/bin/flang # remove for LLVM 20
+RUN <<EOC
+  find /tmp/llvm -name flang-new
+  FLANG_NEW="$(find /tmp/llvm -name flang-new)"
+  FLANG_NEW_DIR="$(dirname $FLANG_NEW)"
+  cd "$FLANG_NEW_DIR"
+  pwd
+  ls -la
+  ln -s flang-new flang # remove for LLVM 20
+EOC
 
 # Patch installed cmake exports/config files to not throw an error if not all components are installed
 COPY patches/ClangTargets.cmake.patch .
@@ -192,7 +200,7 @@ RUN --mount=type=cache,target=/home/salt/ccache <<EOC
   cd tau*
   ./installtau -prefix=/usr/local/ -cc=gcc -c++=g++ -fortran=gfortran\
     -bfd=download -unwind=download -dwarf=download -otf=download -zlib=download -pthread -j
-  ./installtau -prefix=/usr/local/ -cc=clang -c++=clang++ -fortran=flang\
+  ./installtau -prefix=/usr/local/ -cc=clang -c++=clang++ -fortran=flang-new\
     -bfd=download -unwind=download -dwarf=download -otf=download -zlib=download -pthread -j
   cd ..
   rm -rf tau* libdwarf-* otf2-*


### PR DESCRIPTION
`flang-new` is the default name of the flang compiler in LLVM 19, in LLVM 20 it is changing to `flang`

Go back to a partial installation of LLVM/clang/flang components because it's faster and takes up less space.
Finally fix the issue with SALT-FM tests failing in the docker image:

- Configuring TAU with `-fortran=flang` was resulting in an unusable `tau_f90.sh` and, further, introspection in TAU's configure script designed to look for/catch something unrelated was triggered because trying to run `flang` would result in a command not found error.